### PR TITLE
feat: accept and make use of note template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bin/
 
 # Test binary, built with `go test -c`
 *.test
+.pmz.yaml
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/.pmz.yaml.example
+++ b/.pmz.yaml.example
@@ -1,5 +1,6 @@
 editor: your editor path. Example: /usr/bin/vim
 ztldir: your zettel directory - it must exist! Example: /home/<user>/zettel
+notetemplate: if you have a note template you would like to use. Example: /home/<user>/zettel_tmpl.txt
 gitrepo: a link to a remote git repository. Example: git@gitlab.com:<user>/zettel.git
 gituser: your username in that remote git repositories server. 
 repotoken: the access token you generated in that server to grant you programmatic access. Ensure it provides at least read and write access to repositories.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ you will need to update to your own use case. Make a copy in your home directory
 * `pmz search` allows searching for keywords in notes' titles. Afterwards, user can either open or request more to 
 display file contents.
 
+## Templates  
+The program supports a custom template for a new note. It can have the format you want, as long as it contains the 
+`{{.Title}}` variable. If in doubt of what that looks like, please check [the template that exists](./templates/new_note) 
+in this repository. 
+
+You are free to use it too, either by cloning this project or by copying it manually to file in your system. 
+
+To use your custom template, please provide its full path in the configuration file. Check the 
+[sample configuration file](./.pmz.yaml.example) for an example.
+
 
 # CONTRIBUTING  
 When I started building this, I wanted a way to keep a [Zettelkasten](https://zettelkasten.de/) simple and bloat free - 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,18 +21,18 @@ import (
 
 	"github.com/gsilvapt/pmz/internal/logs"
 	"github.com/spf13/cobra"
-
 	"github.com/spf13/viper"
 )
 
 var (
-	cfgFile   string
-	ztldir    string
-	editor    string
-	gitrepo   string
-	gituser   string
-	repotoken string
-	Logger    *logs.Log
+	cfgFile      string
+	ztldir       string
+	notetemplate string
+	editor       string
+	gitrepo      string
+	gituser      string
+	repotoken    string
+	Logger       *logs.Log
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -40,7 +40,11 @@ var rootCmd = &cobra.Command{
 	Use:   "pmz",
 	Short: "Poor Man Zettelkasten CLI",
 	Long: `This is a simple CLI application to help users maintain a Zettelkasten.
-It provides methods to add, search and save your changes into a git repository.`,
+It provides methods to add, search and save your changes into a git repository.
+
+Full documentation can be found in the project's README: https://github.com/gsilvapt/pmz
+`,
+	Version: "0.1",
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
@@ -61,18 +65,18 @@ func init() {
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.pmz.yaml)")
 	rootCmd.PersistentFlags().StringVar(&ztldir, "ztldir", "", "Zettelkasten main directory loaded from config.")
+	rootCmd.PersistentFlags().StringVar(&notetemplate, "notetemplate", "", "Path to template of a new note. Ensure it contains the variables specified in the documentation.")
 	rootCmd.PersistentFlags().StringVar(&editor, "editor", "", "Editor PATH loaded from config file.")
 	rootCmd.PersistentFlags().StringVar(&gitrepo, "gitrepo", "", "Zettelkasten git repository loaded from config.")
 	rootCmd.PersistentFlags().StringVar(&gituser, "gituser", "", "Git username loaded from config.")
 	rootCmd.PersistentFlags().StringVar(&repotoken, "repotoken", "", "Zettelkasten git repository token with **read** and **write** access")
 
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.InitDefaultVersionFlag()
 
 	// Viper binding for global reach
 	viper.BindPFlag("ztldir", rootCmd.PersistentFlags().Lookup("ztldir"))
 	viper.BindPFlag("editor", rootCmd.PersistentFlags().Lookup("editor"))
+	viper.BindPFlag("notetemplate", rootCmd.PersistentFlags().Lookup("notetemplate"))
 	viper.BindPFlag("gitrepo", rootCmd.PersistentFlags().Lookup("gitrepo"))
 	viper.BindPFlag("gituser", rootCmd.PersistentFlags().Lookup("gituser"))
 	viper.BindPFlag("repotoken", rootCmd.PersistentFlags().Lookup("repotoken"))

--- a/templates/new_note
+++ b/templates/new_note
@@ -2,6 +2,5 @@
 
 # Summary
 
-
 # Notes
 


### PR DESCRIPTION
As discussed in #12, this commit adds a feature to let users configure
their own template note.

This commit also adds documentation on how to use the template system. I
am expecting it to grow as this project evolves and thus the need will
come to support more variables, but we will see how it goes.

Should close #12 too.

@acagastya want to take a look to see if this works better? :) 