### PR TITLE
feat: Make use of custom logging class

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -63,12 +63,12 @@ func createZettelEntry(ztldir, dirname string) *os.File {
 	newZtlDir := fmt.Sprintf("%s/%s", ztldir, dirname)
 
 	if err := os.Mkdir(newZtlDir, os.ModePerm); err != nil {
-		PanicIfError(err, "Failed to create directory.")
+		Logger.Error(fmt.Sprintf("failed to create directory: %s", err))
 	}
 
 	f, err := os.Create(fmt.Sprintf("%s/%s", newZtlDir, FILENAME))
 	if err != nil {
-		PanicIfError(err, "Failed to create the file in new dir.")
+		Logger.Error(fmt.Sprintf("failed to create the file in new dir: %s", err))
 	}
 
 	return f
@@ -84,11 +84,11 @@ func writeToNewNote(f *os.File, title string) {
 
 	tmpl, err := template.ParseFiles("templates/new_note")
 	if err != nil {
-		fmt.Println("Failed to write template to new note, but it should exist for you.")
+		Logger.Error("failed to write template to new note, but it should exist for you.")
 	}
 
 	if err := tmpl.Execute(f, tmplData); err != nil {
-		fmt.Println("Failed to write template to new note, but it should exist for you.")
+		Logger.Info("Failed to write template to new note, but it should exist for you.")
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gsilvapt/pmz/internal/logs"
 	"github.com/spf13/cobra"
 
 	"github.com/spf13/viper"
@@ -31,6 +32,7 @@ var (
 	gitrepo   string
 	gituser   string
 	repotoken string
+	Logger    *logs.Log
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -51,6 +53,7 @@ func Execute() {
 }
 
 func init() {
+	Logger = logs.InitLogger()
 	cobra.OnInitialize(initConfig)
 
 	// Here you will define your flags and configuration settings.
@@ -94,6 +97,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
-		fmt.Fprintln(os.Stderr, "Failed reading config file:", viper.ConfigFileUsed())
+		Logger.Error(fmt.Sprintf("Failed reading config file: %s", viper.ConfigFileUsed()))
 	}
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -71,19 +71,25 @@ var searchCmd = &cobra.Command{
 func nextCommand() (string, int) {
 	buffer := bufio.NewReader(os.Stdin)
 	line, err := buffer.ReadString('\n')
-	PanicIfError(err, "failed reading input from screen")
+	if err != nil {
+		Logger.Error(fmt.Sprintf("failed reading input from screen: %s", err))
+	}
 
 	command := strings.Fields(line)
 	idx, err := strconv.Atoi(command[1])
-	PanicIfError(err, "index provided is not a valid number")
+	if err != nil {
+		Logger.Error(fmt.Sprintf("failed reading input from screen: %s", err))
+	}
 
 	return command[0], idx
 }
 
 func readFile(fp string) {
 	dat, err := os.ReadFile(fp)
-	PanicIfError(err, "failed opening specified file")
-	fmt.Println(string(dat))
+	if err != nil {
+		Logger.Error(fmt.Sprintf("failed opening specified file: %s", err))
+	}
+	Logger.Info(string(dat))
 }
 
 func init() {

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -1,0 +1,45 @@
+/*
+Copyright © 2021 GUSTAVO SILVA <gustavosantaremsilva@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"log"
+	"os"
+)
+
+type Log struct {
+	InfoLogger  *log.Logger
+	ErrorLogger *log.Logger
+}
+
+// InitLogger instantiates a struct that provides logging abilities with predefined formats.
+func InitLogger() *Log {
+	return &Log{
+		InfoLogger:  log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile),
+		ErrorLogger: log.New(os.Stdout, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile),
+	}
+}
+
+// Info does a basic STDOUT logging. No side effects on this call.
+func (l *Log) Info(msg string) {
+	l.InfoLogger.Println(msg)
+}
+
+// Error calls Fatal, meaning it logs and exists after call. Use it carefully.
+func (l *Log) Error(msg string) {
+	l.ErrorLogger.Fatalln(msg)
+}

--- a/internal/logs/logger.go
+++ b/internal/logs/logger.go
@@ -1,0 +1,46 @@
+/*
+Copyright © 2021 GUSTAVO SILVA <gustavosantaremsilva@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"log"
+	"os"
+)
+
+// Log is the struct that contains all types of logs used in the application. The motivation for this custom approach
+// is to standardise all logs in the application and also facilitate introducing different verbosity levels.
+// InfoLogger can be used to replace all fmt.Println calls.
+// ErrorLogger can be used to call fatal after logging.
+type Log struct {
+	InfoLogger  *log.Logger
+	ErrorLogger *log.Logger
+}
+
+// InitLogger instantiates three types of logs: An info log, a warn log and an error log.
+func InitLogger() *Log {
+	return &Log{
+		InfoLogger:  log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile),
+		ErrorLogger: log.New(os.Stderr, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile),
+	}
+}
+
+func (l *Log) Info(msg string) {
+	l.InfoLogger.Print(msg)
+}
+func (l *Log) Error(msg string) {
+	l.ErrorLogger.Fatalln(msg)
+}


### PR DESCRIPTION
Deprecate previous logging approach because it was ugly and scary.
This should standardise the command's output and be more flexible as the
project evolves (and its needs).

Solves #14.