### PR TITLE
misc: removes file and line details

### DIFF
--- a/internal/logs/logger.go
+++ b/internal/logs/logger.go
@@ -33,8 +33,8 @@ type Log struct {
 // InitLogger instantiates three types of logs: An info log, a warn log and an error log.
 func InitLogger() *Log {
 	return &Log{
-		InfoLogger:  log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile),
-		ErrorLogger: log.New(os.Stderr, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile),
+		InfoLogger:  log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime),
+		ErrorLogger: log.New(os.Stderr, "ERROR: ", log.Ldate|log.Ltime|log.Llongfile),
 	}
 }
 


### PR DESCRIPTION
Removes unnecessary file and line details from Info logging calls.
Remains on Error for easier debug, although it might be better revise it
some time later.