### PR TITLE
Cmd search tests

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -27,11 +27,11 @@ You will see the new directory and file created in the configured ZTLDIR.
 
 If a template is specified and you use the --title flag, it will try to insert the title in that template.
 `,
-	Run: newCmdRunFunc,
+	Run: newNoteFunc,
 }
 
-// newCmdRunFunc is an isolated func to facilitate writing unit tests to it.
-func newCmdRunFunc(cmd *cobra.Command, args []string) {
+// newNoteFunc is an isolated func to facilitate writing unit tests to it.
+func newNoteFunc(cmd *cobra.Command, args []string) {
 	ztldir := viper.GetString("ztldir")
 	editor := viper.GetString("editor")
 	tmpl_path := viper.GetString("notetemplate")
@@ -51,7 +51,7 @@ func newCmdRunFunc(cmd *cobra.Command, args []string) {
 	}
 
 	if toOpen {
-		OpenFile(f.Name(), editor)
+		openFileInEditor(f.Name(), editor)
 	}
 }
 
@@ -91,7 +91,7 @@ func writeTmplToNote(f *os.File, title, tmplPath string) {
 	}
 
 	if err := tmpl.Execute(f, tmplData); err != nil {
-		Logger.Info("Failed to write template to new note, but the note should exist.")
+		Logger.Error("Failed to write template to new note, but the note should exist.")
 	}
 	return
 }

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewCmdWithNotOpen(t *testing.T) {
 	// GIVEN a _new_ Cobra CMD sruct with the function newCmdRunFunc in the struct
-	newCommand := &cobra.Command{Use: "new command", Run: newCmdRunFunc}
+	newCommand := &cobra.Command{Use: "new command", Run: newNoteFunc}
 
 	// AND GIVEN a viper config with disabled toOpen and a random ztldir attribute
 	tmpDir := t.TempDir()
@@ -55,7 +55,7 @@ func TestNewCmdWithNotOpen(t *testing.T) {
 
 func TestNewCmdWithTitle(t *testing.T) {
 	// GIVEN a _new_ Cobra CMD sruct with the function newCmdRunFunc in the struct
-	newCommand := &cobra.Command{Use: "new command", Run: newCmdRunFunc}
+	newCommand := &cobra.Command{Use: "new command", Run: newNoteFunc}
 
 	// AND GIVEN a viper config with disabled toOpen and a random ztldir attribute
 	tmpDir := t.TempDir()

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestSearchCMDIsAbleToSearchNotesTitle(t *testing.T) {
+	// GIVEN a ztldir with two notes
+	searchCmd := &cobra.Command{Use: "search command", Run: searchCmdFunc}
+
+	// set ztldir to controlled directory for better matching
+	tmpDir := t.TempDir()
+
+	viper.Set("ztldir", tmpDir)
+	// Write fake content to notes
+	var searchableNote string = "Some searchable text\n"
+	noteContents := []string{searchableNote, "Text that will not appear\n"}
+	for idx, note := range noteContents {
+		os.WriteFile(fmt.Sprintf("%s/note%d.md", tmpDir, idx), []byte(note), 0644)
+	}
+
+	// WHEN user searches for any word
+	output, err := ExecuteCmdWithStdinPipe(t, searchCmd, "q\n", "search")
+
+	// THEN the pmz search returns a single note with the searchable content.
+	if err != nil {
+		t.Fatalf("command unexpectably errored out: %s", err)
+	}
+
+	expectedOut := strings.TrimRight(fmt.Sprintf("0 | %s/note0.md: %s", tmpDir, searchableNote), "\n")
+	outLines := strings.Split(output, "\n")
+	actualOut := outLines[0]
+
+	if expectedOut != actualOut {
+		t.Fatalf("expected output to contain note title:\n%s\nand instead got the following:\n%s", expectedOut, actualOut)
+	}
+}
+
+func TestSearchCMDInEmptyDirReturnsNoResults(t *testing.T) {
+	// GIVEN an empty ztldir with no notes
+	searchCmd := &cobra.Command{Use: "search command", Run: searchCmdFunc}
+
+	// set ztldir to controlled directory for better matching
+	tmpDir := t.TempDir()
+	viper.Set("ztldir", tmpDir)
+
+	// WHEN user searches for any word
+	output, err := ExecuteCmdWithStdoutPipe(t, searchCmd, "search")
+
+	// THEN the pmz search returns a single note with the searchable content.
+	if err != nil {
+		t.Fatalf("command unexpectably errored out: %s", err)
+	}
+
+	outLines := strings.Split(output, "\n")
+	actualOut := outLines[0]
+
+	expectedOut := "No results found for query. Exiting..."
+	if expectedOut != actualOut {
+		t.Fatalf("expected output to be:\n%s\nbut instead got:\n%s", expectedOut, actualOut)
+	}
+}

--- a/cmd/test_utils.go
+++ b/cmd/test_utils.go
@@ -2,12 +2,18 @@ package cmd
 
 import (
 	"bytes"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
 
+// ExecuteCmdWithArgsInTest is a wrapper to facilitate calling cobra.Command structs, in which arguments are passed
+// to the Command struct and any potential output from those commands is captured to then be returned.
+// This function **does not wrap os.Stdout nor os.Stderr**.
+// To perform assertions over os.Stdout use ExecuteCmdWithPipes.
 func ExecuteCmdWithArgsInTest(t *testing.T, cmd *cobra.Command, args ...string) (string, error) {
 	t.Helper()
 
@@ -18,4 +24,58 @@ func ExecuteCmdWithArgsInTest(t *testing.T, cmd *cobra.Command, args ...string) 
 
 	err := cmd.Execute()
 	return strings.TrimSpace(buffer.String()), err
+}
+
+// ExecuteCmdWithStdoutPipe is a wrapper to facilitate calling cobra.Command structs, in which arguments are passed to the
+// Command struct, but in this function os.Stdout is captured and returned to the caller.
+// This function **wraps os.Stdout** but not os.Stderr.
+// To perform assertions over Command returned values, use ExecuteCmdWithArgsInTest.
+func ExecuteCmdWithStdoutPipe(t *testing.T, cmd *cobra.Command, args ...string) (string, error) {
+	t.Helper()
+
+	oldOut := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	if err != nil {
+		panic(err)
+	}
+
+	w.Close()
+	buffer, err := io.ReadAll(r)
+	r.Close()
+
+	os.Stdout = oldOut
+	return strings.TrimSpace(string(buffer)), err
+}
+
+func ExecuteCmdWithStdinPipe(t *testing.T, cmd *cobra.Command, toStdin string, args ...string) (string, error) {
+	t.Helper()
+
+	oldOut := os.Stdout
+	oldIn := os.Stdin
+
+	inReader, inWriter, _ := os.Pipe()
+	outReader, outWriter, _ := os.Pipe()
+
+	os.Stdin = inReader
+	os.Stdout = outWriter
+
+	cmd.SetArgs(args)
+
+	inWriter.Write([]byte(toStdin))
+	cmd.Execute()
+
+	inWriter.Close()
+	inReader.Close()
+	outWriter.Close()
+	buffer, err := io.ReadAll(outReader)
+	outReader.Close()
+
+	os.Stdin = oldIn
+	os.Stdout = oldOut
+
+	return strings.TrimSpace(string(buffer)), err
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,20 +1,13 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 )
 
-func PanicIfError(err error, msg string) {
-	if err != nil {
-		panic(fmt.Sprintf("%s: \n %s", msg, err))
-	}
-}
-
-// OpenFile opens the specified file in the editor that both are provided.
+// openFileInEditor opens the specified file in the editor that both are provided.
 // Will likely fail if file does not exist, or path to editor is poor. Callee should ensure both are correct.
-func OpenFile(path, editor string) {
+func openFileInEditor(path, editor string) {
 	cmd := exec.Command(editor, path)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/logs/logger.go
+++ b/internal/logs/logger.go
@@ -10,21 +10,21 @@ import (
 // InfoLogger can be used to replace all fmt.Println calls.
 // ErrorLogger can be used to call fatal after logging.
 type Log struct {
-	InfoLogger  *log.Logger
-	ErrorLogger *log.Logger
+	infoLogger *log.Logger
+	errorLog   *log.Logger
 }
 
 // InitLogger instantiates three types of logs: An info log, a warn log and an error log.
 func InitLogger() *Log {
 	return &Log{
-		InfoLogger:  log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime),
-		ErrorLogger: log.New(os.Stderr, "ERROR: ", log.Ldate|log.Ltime|log.Llongfile),
+		infoLogger: log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime),
+		errorLog:   log.New(os.Stderr, "ERROR: ", log.Ldate|log.Ltime|log.Llongfile),
 	}
 }
 
 func (l *Log) Info(msg string) {
-	l.InfoLogger.Print(msg)
+	l.infoLogger.Print(msg)
 }
 func (l *Log) Error(msg string) {
-	l.ErrorLogger.Fatalln(msg)
+	l.errorLog.Fatalln(msg)
 }

--- a/internal/utils/search_test.go
+++ b/internal/utils/search_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -18,5 +20,38 @@ func TestValidateSupportedExtensions(t *testing.T) {
 		if actual != expected {
 			t.Fail()
 		}
+	}
+}
+
+func TestSearchInEmptyDirAndWithSearchableContent(t *testing.T) {
+	// GIVEN an empty dir
+	emptyTmpDir := t.TempDir()
+
+	// OR GIVEN a temp dir with some notes
+	tmpDir := t.TempDir()
+	var searchableNote string = "Some searchable text\n"
+	noteContents := []string{searchableNote, "Text it will not appear\n"}
+	for idx, note := range noteContents {
+		os.WriteFile(fmt.Sprintf("%s/note%d.md", tmpDir, idx), []byte(note), 0644)
+	}
+
+	// WHEN WalkNoteDir is called with the empty dir
+	emptyResults := WalkNoteDir("search", emptyTmpDir)
+
+	// THEN the result array is empty
+	if len(emptyResults) != 0 {
+		t.Fatalf("expected emptyResults array to be empty but it contains %d in it", len(emptyResults))
+	}
+
+	// BUT WHEN WalkNoteDir is called with the temp dir with some notes
+	foundResults := WalkNoteDir("search", tmpDir)
+
+	// THEN the result array is not empty and only contains the note with matching string
+	if len(foundResults) != 1 {
+		t.Fatalf("expected found results slice to have 1 entry but it contains %d", len(foundResults))
+	}
+
+	if foundResults[0].Context != searchableNote {
+		t.Fatalf("expected \"%s\" to be note's context, but had %s", searchableNote, foundResults[0].Context)
 	}
 }


### PR DESCRIPTION
Isolated command function for better testing. Had a lot of trouble to
capture `stdout` and `stdin` to throw and capture things from and to
commands.
Also added unit tests to the search command that is currently stored in
the `internal` package.

Resolves issue https://github.com/gsilvapt/pmz/issues/17.